### PR TITLE
権限まわりの設定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,20 @@ https://www.balena.io/etcher
 カメラにつないだ状態で、ホームディレクトリで以下を実行する。
 ```
 git clone https://github.com/Hutzper-inc/jetson_setup
-cd jetson_setup/shellscript_setup
+cd jetson_setup
 ./setup.sh
 ```
+
+インストールされるものの一部:
+* vscode
+* ibus-mozc
+* python3-pip
+* build-essential
+* v4l-utils 
+* guvcview
+* firefox 
+* DWService
+* tensorflow, torch, torchvision etc...
 
 すべてうまくインストールできていればYOLOv5のデモがはじまる、はず。  
 yolov5_testのディレクトリの中身は6/15にgit cloneでとってきたもの。  

--- a/setup.sh
+++ b/setup.sh
@@ -5,12 +5,12 @@ echo "Please execute under jetson_setup"
 exit 1
 fi
 
-#新規作成されるファイルを他ユーザーから読み取れないようにする
+#新規作成されるファイルについて、他ユーザーから読み書きできないようにする
 umask 0006
 echo 'umask 0006' >> ~/.bashrc
 
-#home以下を他ユーザーから読み取れないようにする
-chmod o-rwx -R ~/
+#home以下を他ユーザーから読み書きできないようにする
+chmod o-rw -R ~/
 
 # 必須
 sudo apt update

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@ fi
 
 #新規作成されるファイルを他ユーザーから読み取れないようにする
 umask 0006
+echo 'umask 0006' >> ~/.bashrc
 
 #jetson_setupの中身を他ユーザーから読み取れないようにする
 chmod o-rwx -R ../

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,12 @@ echo "Please execute under jetson_setup"
 exit 1
 fi
 
+#新規作成されるファイルを他ユーザーから読み取れないようにする
+umask 0006
+
+#jetson_setupの中身を他ユーザーから読み取れないようにする
+chmod o-rwx -R ../
+
 # 必須
 sudo apt update
 sudo apt upgrade -y 

--- a/setup.sh
+++ b/setup.sh
@@ -9,8 +9,8 @@ fi
 umask 0006
 echo 'umask 0006' >> ~/.bashrc
 
-#jetson_setupの中身を他ユーザーから読み取れないようにする
-chmod o-rwx -R ../
+#home以下を他ユーザーから読み取れないようにする
+chmod o-rwx -R ~/
 
 # 必須
 sudo apt update


### PR DESCRIPTION
他ユーザーのファイルが読み書きできなくなるような設定を追加しました。

umask:  新規作成されるファイル, ディレクトリの権限に制限をかけます。
0006の場合、 o から r + w = 6 の  権限を引き算します。